### PR TITLE
Fix bind issue

### DIFF
--- a/src/tsmart/tsmart.py
+++ b/src/tsmart/tsmart.py
@@ -120,6 +120,7 @@ class TSmart:
                 break
 
         stream.close()
+        sock.close()
 
         return devices.values()
 
@@ -176,6 +177,7 @@ class TSmart:
             break
 
         stream.close()
+        sock.close()
 
         if data is None:
             _LOGGER.warn("Timed-out fetching status from %s" % self.ip)


### PR DESCRIPTION
Socket's weren't being closed, so get '[Error 48] Address already in use' when calling more than one API.
e.g. 
```
Found 1 devices
Traceback (most recent call last):
  File "/Users/chmurray/Documents/Dev/t-smart/tsmart/src/parp.py", line 13, in <module>
    asyncio.run(find_devices())
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/Users/chmurray/Documents/Dev/t-smart/tsmart/src/parp.py", line 9, in find_devices
    await device.async_get_status()
  File "/Users/chmurray/Documents/Dev/t-smart/tsmart/src/tsmart/tsmart.py", line 190, in async_get_status
    response = await self._async_request(request, response_struct)
  File "/Users/chmurray/Documents/Dev/t-smart/tsmart/src/tsmart/tsmart.py", line 136, in _async_request
    sock.bind(("", 1337))
OSError: [Errno 48] Address already in use
```

With fix:
```

Found 1 devices
Thermostat: MEGAflo T-Smart
Temperature: 22.0°C

```
